### PR TITLE
Update slashes in Astro config to fix navigation in GitHub Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,8 +4,8 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://lfbi.pages.github.io/',
-	base: 'documentation-v2',
+	site: 'https://lfbi.pages.github.io',
+	base: '/documentation-v2',
 	integrations: [
 		starlight({
 			title: 'LFBI Student Handbook',


### PR DESCRIPTION
According to the Astro Docs, there should not be a slash at the end of `site`, and there needs to be a slash at the beginning of `base` in the Astro configuration, when deploying to GitHub Pages.