### PR TITLE
Attempt to workaround link issues by appending repo name to site

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,8 +4,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://lfbi.pages.github.io',
-	base: '/documentation-v2',
+	site: 'https://lfbi.pages.github.io/documentation-v2',
 	integrations: [
 		starlight({
 			title: 'LFBI Student Handbook',


### PR DESCRIPTION
It appears that the action configured in the front matter for the splash template does not apply the base value from the Astro configuration. I am appending the base to the site to see if that will work around the issue because Pages deploys with a base URL.