### PR TITLE
Temporarily hardcode the GitHub Pages baseUrl in the Index

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ hero:
     dark: ../../assets/logo-dark.svg
   actions:
     - text: Get Started
-      link: /guides/new-student/
+      link: documentation-v2/guides/new-student/
       icon: right-arrow
 ---
 


### PR DESCRIPTION
Until a proper workaround is found, I am hard coding the repository name (base URL) into the action link for the Hero