### PR TITLE
Undo the hardcoded base URL

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -12,7 +12,7 @@ hero:
     dark: ../../assets/logo-dark.svg
   actions:
     - text: Get Started
-      link: documentation-v2/guides/new-student/
+      link: guides/new-student/
       icon: right-arrow
 ---
 


### PR DESCRIPTION
Remove the base URL from the action link because it doubled the presence of the base URL somehow.